### PR TITLE
Update workflow to use actions/upload-artifact@v3

### DIFF
--- a/air_firmware_esp32cam/.github/workflows/build_firmware.yml
+++ b/air_firmware_esp32cam/.github/workflows/build_firmware.yml
@@ -32,7 +32,7 @@ jobs:
         platformio run -d ${{ matrix.project }}
 
     - name: Upload firmware binaries
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.project }}-firmware
         path: ${{ matrix.project }}/.pio/build/${{ matrix.project }}/*.bin


### PR DESCRIPTION
Update the build workflow to use the latest version of the upload-artifact action.

* Change `actions/upload-artifact@v2` to `actions/upload-artifact@v3` in the "Upload firmware binaries" step of the `air_firmware_esp32cam/.github/workflows/build_firmware.yml` file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RomanLut/hx-esp32-cam-fpv?shareId=0a044d7e-396e-4a64-b97b-cf97e6f95517).